### PR TITLE
Migrate from master/slave terminology

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	index "./modul_index"
-	slaveLocal "./modul_slave_local"
+	subordinateLocal "./modul_subordinate_local"
 	dataprocess "./modul_data_processing"
 
 	"github.com/jasonlvhit/gocron"
@@ -24,7 +24,7 @@ func task() {
 	gettingIndex(yesterday)
 
 	fmt.Println("### stage 2 -", yesterday)
-	slaveToLocal(yesterday)
+	subordinateToLocal(yesterday)
 
 	fmt.Println("### stage 3 -", yesterday)
 	dataProcessing(yesterday)
@@ -36,11 +36,11 @@ func gettingIndex(date string) {
 	index.Dispatch(date, date)
 }
 
-func slaveToLocal(date string) {
-	slaveLocal.Charge(date)
-	slaveLocal.Injections(date)
-	slaveLocal.Subscriptions(date)
-	slaveLocal.Dispatch(date)
+func subordinateToLocal(date string) {
+	subordinateLocal.Charge(date)
+	subordinateLocal.Injections(date)
+	subordinateLocal.Subscriptions(date)
+	subordinateLocal.Dispatch(date)
 }
 
 func dataProcessing(date string) {

--- a/modul_index/charge.go
+++ b/modul_index/charge.go
@@ -11,7 +11,7 @@ import (
 func Charge(first, last string) {
 	fmt.Println("..... Processing index charge .....")
 
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 	dbl := connDB(localInfo)
 
 	defer dbs.Close()

--- a/modul_index/dispatch.go
+++ b/modul_index/dispatch.go
@@ -11,7 +11,7 @@ import (
 func Dispatch(first, last string) {
 	fmt.Println("..... Processing index dispatcher .....")
 
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 	dbl := connDB(localInfo)
 
 	defer dbs.Close()

--- a/modul_index/etc.go
+++ b/modul_index/etc.go
@@ -9,8 +9,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
-var slaveInfo = dbconf{
-	host:     "mobilink-2018-slave-1.cb2q7f7mvbwr.ap-south-1.rds.amazonaws.com",
+var subordinateInfo = dbconf{
+	host:     "mobilink-2018-subordinate-1.cb2q7f7mvbwr.ap-south-1.rds.amazonaws.com",
 	port:     5432,
 	user:     "operations_team",
 	password: "fqzq5PfXjAyuMvR2",

--- a/modul_index/injections.go
+++ b/modul_index/injections.go
@@ -11,7 +11,7 @@ import (
 func Injections(first, last string) {
 	fmt.Println("..... Processing index injections .....")
 
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 	dbl := connDB(localInfo)
 
 	defer dbs.Close()

--- a/modul_slave_local/charge.go
+++ b/modul_slave_local/charge.go
@@ -1,4 +1,4 @@
-package modul_slave_local
+package modul_subordinate_local
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 )
 
 func Charge(date string) {
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 	dbl := connDB(localInfo)
 
 	defer dbs.Close()
@@ -15,7 +15,7 @@ func Charge(date string) {
 	tableName := "charge_all"
 	fid, lid := getIdxCharge(date, dbl)
 
-	fmt.Println("starting insert slave to local data charge |", date)
+	fmt.Println("starting insert subordinate to local data charge |", date)
 	offset := 5000
 	counter := 0
 	for i := 0; true; i++ {

--- a/modul_slave_local/dispatch.go
+++ b/modul_slave_local/dispatch.go
@@ -1,4 +1,4 @@
-package modul_slave_local
+package modul_subordinate_local
 
 import (
 	"database/sql"
@@ -7,7 +7,7 @@ import (
 
 func Dispatch(date string) {
 	dbl := connDB(localInfo)
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 
 	defer dbs.Close()
 	defer dbl.Close()
@@ -15,7 +15,7 @@ func Dispatch(date string) {
 	tableName := "dispatch_all"
 	fid, lid := getIdxDispatch(date, dbl)
 
-	fmt.Println("starting insert slave to local data dispatch |", date)
+	fmt.Println("starting insert subordinate to local data dispatch |", date)
 	offset := 10000
 	counter := 0
 	for i := 0; true; i++ {

--- a/modul_slave_local/etc.go
+++ b/modul_slave_local/etc.go
@@ -1,4 +1,4 @@
-package modul_slave_local
+package modul_subordinate_local
 
 import (
 	"database/sql"
@@ -8,8 +8,8 @@ import (
 	_ "github.com/lib/pq"
 )
 
-var slaveInfo = dbconf{
-	host:     "mobilink-2018-slave-1.cb2q7f7mvbwr.ap-south-1.rds.amazonaws.com",
+var subordinateInfo = dbconf{
+	host:     "mobilink-2018-subordinate-1.cb2q7f7mvbwr.ap-south-1.rds.amazonaws.com",
 	port:     5432,
 	user:     "operations_team",
 	password: "fqzq5PfXjAyuMvR2",

--- a/modul_slave_local/injections.go
+++ b/modul_slave_local/injections.go
@@ -1,4 +1,4 @@
-package modul_slave_local
+package modul_subordinate_local
 
 import (
 	"database/sql"
@@ -7,7 +7,7 @@ import (
 )
 
 func Injections(date string) {
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 	dbl := connDB(localInfo)
 
 	defer dbs.Close()
@@ -16,7 +16,7 @@ func Injections(date string) {
 	tableName := "injections_all"
 	fid, lid := getIdxInjections(date, dbl)
 
-	fmt.Println("starting insert slave to local data injections |", date)
+	fmt.Println("starting insert subordinate to local data injections |", date)
 	offset := 5000
 	counter := 0
 	for i := 0; true; i++ {

--- a/modul_slave_local/subscription.go
+++ b/modul_slave_local/subscription.go
@@ -1,4 +1,4 @@
-package modul_slave_local
+package modul_subordinate_local
 
 import (
 	"database/sql"
@@ -8,7 +8,7 @@ import (
 )
 
 func Subscriptions(date string) {
-	dbs := connDB(slaveInfo)
+	dbs := connDB(subordinateInfo)
 	dbl := connDB(localInfo)
 
 	defer dbs.Close()
@@ -18,7 +18,7 @@ func Subscriptions(date string) {
 	stmt, err := dbl.Prepare("INSERT INTO " + tableName + " VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)")
 	checkError("failed to prepare statement |", err)
 
-	fmt.Println("starting insert slave to local data subscriptions |", date)
+	fmt.Println("starting insert subordinate to local data subscriptions |", date)
 
 	date = strings.Replace(date, " 00:00:00", "", -1)
 	startTime := " 00:00:00"


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.